### PR TITLE
Remove contributors who have indicated that they do not wish to have their work attributed

### DIFF
--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -12,7 +12,6 @@
     "ikhadykin",
     "N-Parsons",
     "pheanex",
-    "sharno",
     "tqa236"
   ],
   "files": {

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -16,7 +16,6 @@
     "oalbe",
     "Peque",
     "pheanex",
-    "sharno",
     "sjakobi",
     "tqa236",
     "twsh",

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -12,7 +12,6 @@
     "N-Parsons",
     "oalbe",
     "pheanex",
-    "sharno",
     "sjakobi",
     "tqa236"
   ],

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -4,7 +4,6 @@
     "sjakobi"
   ],
   "contributors": [
-    "AbstractBeliefs",
     "ackerleytng",
     "behrtam",
     "cmccandless",


### PR DESCRIPTION
`@Sharno` and `@AbstractBeliefs` have indicated they wish to be excluded from PRs that set their data on the Exercism website. This removes them from the config so that their data won't show up on Exercism's website.